### PR TITLE
Avoid conflicting implicit definition of htonl().

### DIFF
--- a/include/qdns.h
+++ b/include/qdns.h
@@ -4,6 +4,7 @@
 #ifndef QSMTP_DNS_H
 #define QSMTP_DNS_H
 
+#include <arpa/inet.h>
 #include <netinet/in.h>
 
 /** @enum mx_special_priorities


### PR DESCRIPTION
Fixes build on at least NetBSD 8.1.